### PR TITLE
fix(playground): support codeblocks with crlf line endings

### DIFF
--- a/playground/src/tools/getSandboxFileCode/getSandboxFileCode.js
+++ b/playground/src/tools/getSandboxFileCode/getSandboxFileCode.js
@@ -1,5 +1,5 @@
 function getSandboxFileCode (code) {
-  return code.replace(/```.*\n/g, '');
+  return code.replace(/```.*\r?\n/g, '');
 }
 
 export { getSandboxFileCode };


### PR DESCRIPTION
_Please make sure you have reviewed the [contribution guidelines](https://github.com/arwes/arwes/blob/main/docs/CONTRIBUTING.md)
for this project._

- [x] Make sure you are making a pull request against the **main branch**
(left side). Also you should start *your branch* off *main*.
- [x] Check the commit's or even all commits' message styles matches our requested
structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

## Description

When running the playground locally on windows, the codeblocks would fail to be replace correctly due to CR in the line endings. This change fixes this issues - though i have not been able to test on other platforms.
