### PR TITLE
Add Github Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+# This workflow will do a clean install of node dependencies
+# and run the test/build commands for `npm run ci`
+
+name: ci
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.15]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci && npm run ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-script: npm run ci
-language: node_js
-node_js:
-  - "14.15"
-os:
-  - linux

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
     <a href="https://npmjs.org/package/@arwes/arwes">
         <img src="https://img.shields.io/npm/v/@arwes/arwes.svg" alt="version" />
     </a>
-    <a href="https://travis-ci.org/arwes/arwes">
-        <img src="https://img.shields.io/travis/arwes/arwes.svg" alt="travis" />
+    <a href="https://github.com/arwes/arwes/actions">
+        <img src="https://github.com/arwes/arwes/workflows/ci/badge.svg" alt="ci" />
     </a>
     <a href="https://github.com/arwes/arwes">
         <img src="https://img.shields.io/github/stars/arwes/arwes.svg?style=social&label=stars" alt="github stars" />


### PR DESCRIPTION
_Please make sure you have reviewed the [contribution guidelines](https://github.com/arwes/arwes/blob/main/docs/CONTRIBUTING.md)
for this project._

- [x] Make sure you are making a pull request against the **main branch**
(left side). Also you should start *your branch* off *main*.
- [x] Check the commit's or even all commits' message styles matches our requested
structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

## Description

This pull request adds a Github Action workflow for running CI whenever a pull request is made against `main` and whenever a commit is made to `main`. 

See `.github/workflows/ci.yml` below for the job spec

Notes:

- The job runs `npm ci && npm run ci` on Node v. 14.15, copied these commands and this Node version from the Travis job
- Ran this a few times on my fork, job usually takes 50-60 seconds to run from setup to completion, with `npm ci && npm run ci` taking only ~44 seconds each time. [Example job summary](https://github.com/njwest/arwes/runs/1574453907?check_suite_focus=true)
- Replaced the Travis badge with a Github Action badge in the Readme that links to the Arwes Actions panel, it appears as so (screenshot from my fork's [Main branch]( https://github.com/njwest/arwes) readme):

![Screen Shot 2020-12-18 at 11 22 29 AM](https://user-images.githubusercontent.com/3742496/102571447-72779600-4124-11eb-9335-63ddbccead5e.png)

Let me know if you prefer to stick with build: passed on the badge as in the old format and I'll edit the workflow/badge on my pull-requested branch.

 :alien: :blue_heart:
