### PR TITLE
fix(animation): improve typing of withAnimator HOC

### DIFF
--- a/packages/animation/src/withAnimator/withAnimator.test.tsx
+++ b/packages/animation/src/withAnimator/withAnimator.test.tsx
@@ -48,7 +48,7 @@ test('Should add <Animator/> wrapper and provide "animator" settings to componen
         animator = props.animator;
         return null;
       };
-      const ExampleNode = withAnimator(classSettings)(ExampleComponent);
+      const ExampleNode = withAnimator<typeof ExampleComponent>(classSettings)(ExampleComponent);
       render(<ExampleNode animator={instanceSettings} />);
       expect(animator.animate).toBe(false);
       expect(animator.flow.value).toBe(ENTERED);
@@ -183,13 +183,13 @@ test('Should allow passing a "ref" to wrapped component', () => {
       return 100;
     }
   }
-  const ExampleNode = withAnimator()(ExampleComponent);
+  const ExampleNode = withAnimator<ExampleComponent>()(ExampleComponent);
 
   const ExampleApp: FC = () => {
-    const ref = useRef<any>();
+    const ref = useRef<ExampleComponent>(null);
 
     useEffect(() => {
-      expect(ref.current.hello()).toBe(100);
+      expect(ref.current?.hello()).toBe(100);
     }, []);
 
     return (

--- a/packages/animation/src/withAnimator/withAnimator.ts
+++ b/packages/animation/src/withAnimator/withAnimator.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 
-import { ComponentType, FC, Ref, createElement, forwardRef } from 'react';
+import { ComponentType, FC, createElement, forwardRef, Component, Ref } from 'react';
 
 import { AnimatorClassSettings, AnimatorInstanceSettings, AnimatorProvidedSettings } from '../constants';
 import { mergeClassAndInstanceAnimatorSettings } from '../utils/mergeClassAndInstanceAnimatorSettings';
@@ -15,11 +15,11 @@ interface WithAnimatorOutputProps {
   animator?: AnimatorInstanceSettings
 }
 
-function withAnimator (classAnimator?: AnimatorClassSettings) {
+function withAnimator<T extends Component<WithAnimatorInputProps> | FC<WithAnimatorInputProps>> (classAnimator?: AnimatorClassSettings) {
   const withAnimatorWrapper = <P extends WithAnimatorInputProps>(InputComponent: ComponentType<P>) => {
     interface AnimatorMiddlewareProps {
       InputComponent: ComponentType<P>
-      forwardedRef: Ref<any>
+      forwardedRef: Ref<T>
     }
 
     const AnimatorMiddleware: FC<AnimatorMiddlewareProps> = props => {
@@ -38,7 +38,7 @@ function withAnimator (classAnimator?: AnimatorClassSettings) {
     // The output component will optionally allow the `animator: AnimatorInstanceSettings` prop.
     type C = Pick<P, Exclude<keyof P, keyof WithAnimatorInputProps>> & WithAnimatorOutputProps;
 
-    const OutputComponent = forwardRef<Ref<any>, C>((props, forwardedRef) => {
+    const OutputComponent = forwardRef<T, C>((props, forwardedRef) => {
       const { animator: instanceAnimator, ...otherProps } = props;
       const resultAnimator = mergeClassAndInstanceAnimatorSettings(classAnimator, instanceAnimator);
 


### PR DESCRIPTION
_Please make sure you have reviewed the [contribution guidelines](https://github.com/arwes/arwes/blob/main/docs/CONTRIBUTING.md)
for this project._

- [ ] Make sure you are making a pull request against the **main branch**
(left side). Also you should start *your branch* off *main*.
- [x] Check the commit's or even all commits' message styles matches our requested
structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

## Description

This change should improve type inference for withAnimator HOC