### PR TITLE
test(sounds): withBleeps class component forwardRef TypeScript support

### DIFF
--- a/packages/sounds/src/withBleeps/withBleeps.test.tsx
+++ b/packages/sounds/src/withBleeps/withBleeps.test.tsx
@@ -153,3 +153,43 @@ test('Should throw error if there is not provider found', () => {
   expect(mockErrorCatcher.error?.message).toBe('Component with bleeps requires <BleepsProvider/> settings.');
   expect(mockConsoleError).toHaveBeenCalled();
 });
+
+test('Should allow passing a "ref" to wrapped component', () => {
+  const audio = {
+    common: { volume: 0.5 }
+  };
+  const players = {
+    tap: { src: ['tap.webm'] }
+  };
+  class ExampleComponent extends React.Component<WithBleepsInputProps> {
+    render (): React.ReactNode {
+      return null;
+    }
+
+    hello (): number {
+      return 100;
+    }
+  }
+  const bleepsSettings: BleepsSettings = {
+    click: { player: 'tap' }
+  };
+  const Example = withBleeps(bleepsSettings)(ExampleComponent);
+
+  let helloResponse: any;
+  const ExampleApp: FC = () => {
+    const ref = React.useRef<ExampleComponent | null>(null);
+
+    React.useEffect(() => {
+      helloResponse = ref.current?.hello();
+    }, []);
+
+    return (
+      <BleepsProvider audio={audio} players={players}>
+        <Example ref={ref} />
+      </BleepsProvider>
+    );
+  };
+
+  render(<ExampleApp />);
+  expect(helloResponse).toBe(100);
+});


### PR DESCRIPTION
Please make sure you have reviewed the [contribution guidelines](https://arwes.dev/project/contributing) for this project.

- [x] Make sure you are making a pull request against the **main branch**
(left side). Also you should start *your branch* off *main*.
- [x] Check the commit's or even all commits' message styles matches our requested
structure.
- [ ] Check your code additions will fail neither code linting checks nor unit test.

## Description

Add test case for `withBleeps` HOC with forwardRef to class component.

Since the TypeScript typing is not very compatible with that use case, we need a way to enable this use case.
