### PR TITLE
fix(withanimation, framecorners, table, tablerow): fix typing

### DIFF
--- a/packages/animation/src/withAnimator/withAnimator.ts
+++ b/packages/animation/src/withAnimator/withAnimator.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 
-import { ComponentType, FC, createElement, forwardRef, Ref, ForwardRefExoticComponent, PropsWithoutRef, RefAttributes } from 'react';
-
 import { AnimatorClassSettings, AnimatorInstanceSettings, AnimatorRef } from '../constants';
-import { mergeClassAndInstanceAnimatorSettings } from '../utils/mergeClassAndInstanceAnimatorSettings';
+import React, { ComponentType, FC, ForwardRefExoticComponent, PropsWithoutRef, Ref, RefAttributes, createElement, forwardRef } from 'react';
+
 import { Animator } from '../Animator';
+import { mergeClassAndInstanceAnimatorSettings } from '../utils/mergeClassAndInstanceAnimatorSettings';
 import { useAnimator } from '../useAnimator';
 
 interface WithAnimatorInputProps {
@@ -15,8 +15,8 @@ interface WithAnimatorOutputProps {
   animator?: AnimatorInstanceSettings
 }
 
-function withAnimator<T extends ComponentType<P>, P extends WithAnimatorInputProps = WithAnimatorInputProps> (classAnimator?: AnimatorClassSettings) {
-  const withAnimatorWrapper = (InputComponent: T) => {
+function withAnimator (classAnimator?: AnimatorClassSettings) {
+  const withAnimatorWrapper = <T extends ComponentType<P>, P extends WithAnimatorInputProps = React.ComponentProps<T>>(InputComponent: T) => {
     interface AnimatorMiddlewareProps {
       InputComponent: T
       forwardedRef: Ref<T>

--- a/packages/core/src/Figure/index.ts
+++ b/packages/core/src/Figure/index.ts
@@ -1,10 +1,10 @@
-import { FC } from 'react';
+import { Figure as Component, FigureProps } from './Figure.component';
 import { WithAnimatorOutputProps, withAnimator } from '@arwes/animation';
 
-import { FigureProps, Figure as Component } from './Figure.component';
+import { FC } from 'react';
 import { animator } from './Figure.animator';
 
 // TODO: Fix props or HOC to properly use nested component props with withAnimator.
-const Figure: FC<FigureProps & WithAnimatorOutputProps> = withAnimator(animator)(Component as any);
+const Figure: FC<FigureProps & WithAnimatorOutputProps> = withAnimator(animator)(Component);
 
 export { FigureProps, Figure };

--- a/packages/core/src/FrameCorners/index.ts
+++ b/packages/core/src/FrameCorners/index.ts
@@ -1,9 +1,9 @@
-import { withAnimator } from '@arwes/animation';
+import { FrameCorners as Component, FrameCornersProps } from './FrameCorners.component';
 
-import { FrameCornersProps, FrameCorners as Component } from './FrameCorners.component';
+import { withAnimator } from '@arwes/animation';
 
 // TODO: withAnimator does not support a functional React component declared
 // in "function Component () {}" notation with "defaultProps".
-const FrameCorners = withAnimator()(Component as any);
+const FrameCorners = withAnimator()(Component);
 
 export { FrameCornersProps, FrameCorners };

--- a/packages/core/src/Table/TableRow/index.ts
+++ b/packages/core/src/Table/TableRow/index.ts
@@ -1,16 +1,16 @@
-import { FC } from 'react';
+import {
+  TableRow as Component,
+  TableRowProps,
+  TableRowPropsColumn,
+  TableRowPropsColumnWidth
+} from './TableRow.component';
 import { WithAnimatorOutputProps, withAnimator } from '@arwes/animation';
 
-import {
-  TableRowPropsColumn,
-  TableRowPropsColumnWidth,
-  TableRowProps,
-  TableRow as Component
-} from './TableRow.component';
+import { FC } from 'react';
 import { animator } from './TableRow.animator';
 
 // TODO: Fix props or HOC to properly use nested component props with withAnimator.
-const TableRow: FC<TableRowProps & WithAnimatorOutputProps> = withAnimator(animator)(Component as any);
+const TableRow: FC<TableRowProps & WithAnimatorOutputProps> = withAnimator(animator)(Component);
 
 export {
   TableRowPropsColumn,

--- a/packages/core/src/Table/index.ts
+++ b/packages/core/src/Table/index.ts
@@ -1,10 +1,10 @@
-import { FC } from 'react';
+import { Table as Component, TableProps } from './Table.component';
 import { WithAnimatorOutputProps, withAnimator } from '@arwes/animation';
 
-import { TableProps, Table as Component } from './Table.component';
+import { FC } from 'react';
 import { animator } from './Table.animator';
 
 // TODO: Fix props or HOC to properly use nested component props with withAnimator.
-const Table: FC<TableProps & WithAnimatorOutputProps> = withAnimator(animator)(Component as any);
+const Table: FC<TableProps & WithAnimatorOutputProps> = withAnimator(animator)(Component);
 
 export { TableProps, Table };


### PR DESCRIPTION
Please make sure you have reviewed the [contribution guidelines](https://arwes.dev/project/contributing)
for this project.

- [X] Make sure you are making a pull request against the **main** or **next** branches
(left side). Also you should start *your branch* off one of them.
- [X] Check the commit's or even all commits' message styles matches our requested
structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.

## Description

Improving the type signature of `withAnimation` and `FrameCorners`,
`Table`, `TableRow`, probably addressing some `TODO` tech-debt (not issues)

This will fix a blocker type-check failure I've encountered in my own project when using `FrameCorners` with children: `Property 'children' does not exist on type 'IntrinsicAttributes & Pick<Pick<WithAnimatorInputProps, never> & bla bla bla'`

