### PR TITLE
fix-typings

### DIFF
--- a/packages/animator/src/withAnimator/withAnimator.test.tsx
+++ b/packages/animator/src/withAnimator/withAnimator.test.tsx
@@ -1,9 +1,9 @@
 /* eslint-env jest */
 
-import React, { createRef, FC, ReactNode, useEffect } from 'react';
-import { render, cleanup, act } from '@testing-library/react';
+import { AnimatorClassSettings, AnimatorRef, ENTERED, ENTERING, EXITED } from '../constants';
+import React, { FC, ReactNode, createRef, useEffect } from 'react';
+import { act, cleanup, render } from '@testing-library/react';
 
-import { EXITED, ENTERED, ENTERING, AnimatorRef, AnimatorClassSettings } from '../constants';
 import { Animator } from '../Animator';
 import { withAnimator } from './withAnimator';
 
@@ -48,7 +48,7 @@ test('Should add <Animator/> wrapper and provide "animator" settings to componen
         animator = props.animator;
         return null;
       };
-      const ExampleNode = withAnimator<typeof ExampleComponent>(classSettings)(ExampleComponent);
+      const ExampleNode = withAnimator(classSettings)<typeof ExampleComponent>(ExampleComponent);
       render(<ExampleNode animator={instanceSettings} />);
       expect(animator.animate).toBe(false);
       expect(animator.flow.value).toBe(ENTERED);

--- a/packages/animator/src/withAnimator/withAnimator.ts
+++ b/packages/animator/src/withAnimator/withAnimator.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 
-import { ComponentType, FC, createElement, forwardRef, Ref, ForwardRefExoticComponent, PropsWithoutRef, RefAttributes } from 'react';
-
 import { AnimatorClassSettings, AnimatorInstanceSettings, AnimatorRef } from '../constants';
-import { mergeClassAndInstanceAnimatorSettings } from '../utils/mergeClassAndInstanceAnimatorSettings';
+import { ComponentType, FC, ForwardRefExoticComponent, PropsWithoutRef, Ref, RefAttributes, createElement, forwardRef } from 'react';
+
 import { Animator } from '../Animator';
+import { mergeClassAndInstanceAnimatorSettings } from '../utils/mergeClassAndInstanceAnimatorSettings';
 import { useAnimator } from '../useAnimator';
 
 interface WithAnimatorInputProps {
@@ -15,8 +15,8 @@ interface WithAnimatorOutputProps {
   animator?: AnimatorInstanceSettings
 }
 
-function withAnimator<T extends ComponentType<P>, P extends WithAnimatorInputProps = WithAnimatorInputProps> (classAnimator?: AnimatorClassSettings) {
-  const withAnimatorWrapper = (InputComponent: T) => {
+function withAnimator (classAnimator?: AnimatorClassSettings) {
+  const withAnimatorWrapper = <T extends ComponentType<P>, P extends WithAnimatorInputProps = React.ComponentProps<T>>(InputComponent: T) => {
     interface AnimatorMiddlewareProps {
       InputComponent: T
       forwardedRef: Ref<T>

--- a/packages/core/src/Blockquote/index.ts
+++ b/packages/core/src/Blockquote/index.ts
@@ -1,12 +1,10 @@
-import { FC } from 'react';
-import { AnimatorClassSettings, WithAnimatorOutputProps, withAnimator } from '@arwes/animator';
-
+import { AnimatorClassSettings, withAnimator } from '@arwes/animator';
 import { BlockquoteProps, Blockquote as Component } from './Blockquote.component';
 
 const classAnimatorSettings: AnimatorClassSettings = {
   manager: 'stagger'
 };
 
-const Blockquote: FC<BlockquoteProps & WithAnimatorOutputProps> = withAnimator(classAnimatorSettings)(Component);
+const Blockquote = withAnimator(classAnimatorSettings)(Component);
 
 export { BlockquoteProps, Blockquote };

--- a/packages/core/src/Card/index.ts
+++ b/packages/core/src/Card/index.ts
@@ -1,9 +1,8 @@
-import { FC } from 'react';
-import { WithAnimatorOutputProps, withAnimator } from '@arwes/animator';
-
 import { CardProps, Card as Component } from './Card.component';
-import { animator } from './Card.animator';
 
-const Card: FC<CardProps & WithAnimatorOutputProps> = withAnimator(animator)(Component);
+import { animator } from './Card.animator';
+import { withAnimator } from '@arwes/animator';
+
+const Card = withAnimator(animator)(Component);
 
 export { CardProps, Card };

--- a/packages/core/src/CodeBlock/index.ts
+++ b/packages/core/src/CodeBlock/index.ts
@@ -1,9 +1,8 @@
-import { FC } from 'react';
-import { WithAnimatorOutputProps, withAnimator } from '@arwes/animator';
-
 import { CodeBlockProps, CodeBlock as Component } from './CodeBlock.component';
-import { animator } from './CodeBlock.animator';
 
-const CodeBlock: FC<CodeBlockProps & WithAnimatorOutputProps> = withAnimator(animator)(Component);
+import { animator } from './CodeBlock.animator';
+import { withAnimator } from '@arwes/animator';
+
+const CodeBlock = withAnimator(animator)(Component);
 
 export { CodeBlockProps, CodeBlock };

--- a/packages/core/src/Figure/index.ts
+++ b/packages/core/src/Figure/index.ts
@@ -1,10 +1,8 @@
-import { FC } from 'react';
-import { WithAnimatorOutputProps, withAnimator } from '@arwes/animator';
+import { Figure as Component, FigureProps } from './Figure.component';
 
-import { FigureProps, Figure as Component } from './Figure.component';
 import { animator } from './Figure.animator';
+import { withAnimator } from '@arwes/animator';
 
-// TODO: Fix props or HOC to properly use nested component props with withAnimator.
-const Figure: FC<FigureProps & WithAnimatorOutputProps> = withAnimator(animator)(Component as any);
+const Figure = withAnimator(animator)(Component);
 
 export { FigureProps, Figure };

--- a/packages/core/src/FrameBox/index.ts
+++ b/packages/core/src/FrameBox/index.ts
@@ -1,10 +1,7 @@
-import { FC } from 'react';
-import { WithAnimatorOutputProps, withAnimator } from '@arwes/animator';
+import { FrameBox as Component, FrameBoxProps } from './FrameBox.component';
 
-import { FrameBoxProps, FrameBox as Component } from './FrameBox.component';
+import { withAnimator } from '@arwes/animator';
 
-// TODO: withAnimator does not support a functional React component declared
-// in "function Component () {}" notation with "defaultProps".
-const FrameBox: FC<FrameBoxProps<HTMLDivElement> & WithAnimatorOutputProps> = withAnimator()(Component as any);
+const FrameBox = withAnimator()(Component);
 
 export { FrameBoxProps, FrameBox };

--- a/packages/core/src/FrameCorners/index.ts
+++ b/packages/core/src/FrameCorners/index.ts
@@ -1,10 +1,7 @@
-import { FC } from 'react';
-import { WithAnimatorOutputProps, withAnimator } from '@arwes/animator';
+import { FrameCorners as Component, FrameCornersProps } from './FrameCorners.component';
 
-import { FrameCornersProps, FrameCorners as Component } from './FrameCorners.component';
+import { withAnimator } from '@arwes/animator';
 
-// TODO: withAnimator does not support a functional React component declared
-// in "function Component () {}" notation with "defaultProps".
-const FrameCorners: FC<FrameCornersProps<HTMLDivElement> & WithAnimatorOutputProps> = withAnimator()(Component as any);
+const FrameCorners = withAnimator()(Component);
 
 export { FrameCornersProps, FrameCorners };

--- a/packages/core/src/FrameHexagon/index.ts
+++ b/packages/core/src/FrameHexagon/index.ts
@@ -1,10 +1,7 @@
-import { FC } from 'react';
-import { WithAnimatorOutputProps, withAnimator } from '@arwes/animator';
+import { FrameHexagon as Component, FrameHexagonProps } from './FrameHexagon.component';
 
-import { FrameHexagonProps, FrameHexagon as Component } from './FrameHexagon.component';
+import { withAnimator } from '@arwes/animator';
 
-// TODO: withAnimator does not support a functional React component declared
-// in "function Component () {}" notation with "defaultProps".
-const FrameHexagon: FC<FrameHexagonProps<HTMLDivElement> & WithAnimatorOutputProps> = withAnimator()(Component as any);
+const FrameHexagon = withAnimator()(Component);
 
 export { FrameHexagonProps, FrameHexagon };

--- a/packages/core/src/FrameLines/index.ts
+++ b/packages/core/src/FrameLines/index.ts
@@ -1,10 +1,7 @@
-import { FC } from 'react';
-import { WithAnimatorOutputProps, withAnimator } from '@arwes/animator';
+import { FrameLines as Component, FrameLinesProps } from './FrameLines.component';
 
-import { FrameLinesProps, FrameLines as Component } from './FrameLines.component';
+import { withAnimator } from '@arwes/animator';
 
-// TODO: withAnimator does not support a functional React component declared
-// in "function Component () {}" notation with "defaultProps".
-const FrameLines: FC<FrameLinesProps<HTMLDivElement> & WithAnimatorOutputProps> = withAnimator()(Component as any);
+const FrameLines = withAnimator()(Component);
 
 export { FrameLinesProps, FrameLines };

--- a/packages/core/src/FramePentagon/index.ts
+++ b/packages/core/src/FramePentagon/index.ts
@@ -1,10 +1,7 @@
-import { FC } from 'react';
-import { WithAnimatorOutputProps, withAnimator } from '@arwes/animator';
+import { FramePentagon as Component, FramePentagonProps } from './FramePentagon.component';
 
-import { FramePentagonProps, FramePentagon as Component } from './FramePentagon.component';
+import { withAnimator } from '@arwes/animator';
 
-// TODO: withAnimator does not support a functional React component declared
-// in "function Component () {}" notation with "defaultProps".
-const FramePentagon: FC<FramePentagonProps<HTMLDivElement> & WithAnimatorOutputProps> = withAnimator()(Component as any);
+const FramePentagon = withAnimator()(Component);
 
 export { FramePentagonProps, FramePentagon };

--- a/packages/core/src/FrameUnderline/index.ts
+++ b/packages/core/src/FrameUnderline/index.ts
@@ -1,10 +1,7 @@
-import { FC } from 'react';
-import { WithAnimatorOutputProps, withAnimator } from '@arwes/animator';
+import { FrameUnderline as Component, FrameUnderlineProps } from './FrameUnderline.component';
 
-import { FrameUnderlineProps, FrameUnderline as Component } from './FrameUnderline.component';
+import { withAnimator } from '@arwes/animator';
 
-// TODO: withAnimator does not support a functional React component declared
-// in "function Component () {}" notation with "defaultProps".
-const FrameUnderline: FC<FrameUnderlineProps<HTMLDivElement> & WithAnimatorOutputProps> = withAnimator()(Component as any);
+const FrameUnderline = withAnimator()(Component);
 
 export { FrameUnderlineProps, FrameUnderline };

--- a/packages/core/src/List/index.ts
+++ b/packages/core/src/List/index.ts
@@ -1,9 +1,8 @@
-import { FC } from 'react';
-import { WithAnimatorOutputProps, withAnimator } from '@arwes/animator';
+import { List as Component, ListProps } from './List.component';
 
-import { ListProps, List as Component } from './List.component';
 import { animator } from './List.animator';
+import { withAnimator } from '@arwes/animator';
 
-const List: FC<ListProps & WithAnimatorOutputProps> = withAnimator(animator)(Component);
+const List = withAnimator(animator)(Component);
 
 export { ListProps, List };

--- a/packages/core/src/LoadingBars/index.ts
+++ b/packages/core/src/LoadingBars/index.ts
@@ -1,9 +1,8 @@
-import { FC } from 'react';
-import { WithAnimatorOutputProps, withAnimator } from '@arwes/animator';
+import { LoadingBars as Component, LoadingBarsProps } from './LoadingBars.component';
 
-import { LoadingBarsProps, LoadingBars as Component } from './LoadingBars.component';
 import { animator } from './LoadingBars.animator';
+import { withAnimator } from '@arwes/animator';
 
-const LoadingBars: FC<LoadingBarsProps & WithAnimatorOutputProps> = withAnimator(animator)(Component);
+const LoadingBars = withAnimator(animator)(Component);
 
 export { LoadingBarsProps, LoadingBars };

--- a/packages/core/src/Table/TableRow/index.ts
+++ b/packages/core/src/Table/TableRow/index.ts
@@ -1,16 +1,14 @@
-import { FC } from 'react';
-import { WithAnimatorOutputProps, withAnimator } from '@arwes/animator';
-
 import {
-  TableRowPropsColumn,
-  TableRowPropsColumnWidth,
+  TableRow as Component,
   TableRowProps,
-  TableRow as Component
+  TableRowPropsColumn,
+  TableRowPropsColumnWidth
 } from './TableRow.component';
-import { animator } from './TableRow.animator';
 
-// TODO: Fix props or HOC to properly use nested component props with withAnimator.
-const TableRow: FC<TableRowProps & WithAnimatorOutputProps> = withAnimator(animator)(Component as any);
+import { animator } from './TableRow.animator';
+import { withAnimator } from '@arwes/animator';
+
+const TableRow = withAnimator(animator)(Component);
 
 export {
   TableRowPropsColumn,

--- a/packages/core/src/Table/index.ts
+++ b/packages/core/src/Table/index.ts
@@ -1,10 +1,8 @@
-import { FC } from 'react';
-import { WithAnimatorOutputProps, withAnimator } from '@arwes/animator';
+import { Table as Component, TableProps } from './Table.component';
 
-import { TableProps, Table as Component } from './Table.component';
 import { animator } from './Table.animator';
+import { withAnimator } from '@arwes/animator';
 
-// TODO: Fix props or HOC to properly use nested component props with withAnimator.
-const Table: FC<TableProps & WithAnimatorOutputProps> = withAnimator(animator)(Component as any);
+const Table = withAnimator(animator)(Component);
 
 export { TableProps, Table };

--- a/packages/core/src/Text/index.ts
+++ b/packages/core/src/Text/index.ts
@@ -1,9 +1,8 @@
-import { FC } from 'react';
-import { WithAnimatorOutputProps, withAnimator } from '@arwes/animator';
+import { Text as Component, TextProps } from './Text.component';
 
-import { TextProps, Text as Component } from './Text.component';
 import { animator } from './Text.animator';
+import { withAnimator } from '@arwes/animator';
 
-const Text: FC<TextProps & WithAnimatorOutputProps> = withAnimator(animator)(Component);
+const Text = withAnimator(animator)(Component);
 
 export { TextProps, Text };


### PR DESCRIPTION
Please make sure you have reviewed the [contribution guidelines](https://arwes.dev/project/contributing)
for this project.

- [X] Make sure you are making a pull request against the **main** or **next** branches
(left side). Also you should start *your branch* off one of them.
- [X] Check the commit's or even all commits' message styles matches our requested
structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.

## Description
( this PR replaces #119 )
Improving the type signature of `withAnimation` and `FrameCorners`,
`Table`, `TableRow`, probably addressing some `TODO` tech-debt (not issues)

This will fix a blocker type-check failure I've encountered in my own project when using `FrameCorners` with children: `Property 'children' does not exist on type 'IntrinsicAttributes & Pick<Pick<WithAnimatorInputProps, never> & bla bla bla'`
