### PR TITLE
fix(Text component): enter time

### DIFF
--- a/packages/core/src/Text/Text.component.ts
+++ b/packages/core/src/Text/Text.component.ts
@@ -123,7 +123,7 @@ const Text: FC<TextProps & WithAnimatorInputProps> = props => {
     if (dynamicDuration) {
       const newChildrenTextContent = String(actualChildrenRef.current?.textContent || '');
       const factor = dynamicDurationFactor || FPS_NORMAL_DURATION;
-      const newDynamicDuration = Math.min(
+      const newDynamicDuration = Math.max(
         factor * newChildrenTextContent.length,
         animator.duration.enter
       );


### PR DESCRIPTION
Fix enter animation time of Text component

Please make sure you have reviewed the [contribution guidelines](https://arwes.dev/project/contributing)
for this project.

- [X] Make sure you are making a pull request against the **main** or **next** branches
(left side). Also you should start *your branch* off one of them.
- [X] Check the commit's or even all commits' message styles matches our requested
structure.
- [ ] Check your code additions will fail neither code linting checks nor unit test.

## Description
I've noticed that the text component ignores large enter times, I assume it's a bug of confusing the min/max methods. I've tested the fix directly in my project's node_modules, and am using github to commit the change, so didn't run tests locally.


Thank you! :alien: :blue_heart:
