### PR TITLE
fix(animator): ensure onAnimate(Enter|Exit)ing is always called before onAnimate(Enter|Exit)ed

### DIFF
--- a/packages/animator/src/Animator/Animator.component.ts
+++ b/packages/animator/src/Animator/Animator.component.ts
@@ -346,15 +346,26 @@ const Animator: FC<AnimatorProps> = props => {
       setActivate(animator.activate !== false);
     }
 
+    const previousFlowValue = previousAnimatorRef.current?.flow.value;
     // If the flow value was changed in this update.
-    if (previousAnimatorRef.current?.flow.value !== flow.value) {
+    if (previousFlowValue !== flow.value) {
       animator.onTransition?.(flow);
 
       switch (flow.value) {
         case ENTERING: animator.onAnimateEntering?.(publicAnimatorRef, ...animateRefs.current); break;
-        case ENTERED: animator.onAnimateEntered?.(publicAnimatorRef, ...animateRefs.current); break;
+        case ENTERED:
+          if (previousFlowValue && previousFlowValue !== 'entering') {
+            animator.onAnimateEntering?.(publicAnimatorRef, ...animateRefs.current);
+          }
+          animator.onAnimateEntered?.(publicAnimatorRef, ...animateRefs.current);
+          break;
         case EXITING: animator.onAnimateExiting?.(publicAnimatorRef, ...animateRefs.current); break;
-        case EXITED: animator.onAnimateExited?.(publicAnimatorRef, ...animateRefs.current); break;
+        case EXITED:
+          if (previousFlowValue && previousFlowValue !== 'exiting') {
+            animator.onAnimateExiting?.(publicAnimatorRef, ...animateRefs.current);
+          }
+          animator.onAnimateExited?.(publicAnimatorRef, ...animateRefs.current);
+          break;
       }
 
       if (childActivations.current?.times.length) {


### PR DESCRIPTION
Please make sure you have reviewed the [contribution guidelines](https://arwes.dev/project/contributing)
for this project.

- [x] Make sure you are making a pull request against the **next** branch
(left side). Also you should start *your branch* off it.
- [x] Check the commit's or even all commits' message styles matches our requested
structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

## Description

Animator is currently relying on this useEffect firing between _persistentAnimatorRef being set to a flow value of "entering" or "exiting" and before it's set to "entered" or "exited", which isn't guaranteed. This PR adds checks to ensure we have called onAnimate(Enter|Exit)ing before calling onAnimate(Enter|Exit)ed which is one way to solve this problem.
