### PR TITLE
feat(animator): withAnimator component generic types support

### DIFF
--- a/packages/animator/src/withAnimator/withAnimator.test.tsx
+++ b/packages/animator/src/withAnimator/withAnimator.test.tsx
@@ -219,6 +219,23 @@ test('Should "animator.manager" setting take priority in instance setting', () =
   expect(animator).toMatchObject({ manager: 'stagger' });
 });
 
+test('Should accept function component with generic types', () => {
+  interface ExampleComponentProps<T> {
+    title: T
+    disabled?: boolean
+  }
+  const ExampleComponent = <T extends string = string>(props: ExampleComponentProps<T>): React.ReactElement => {
+    return <div>{props.title}</div>;
+  };
+  const ExampleNode = withAnimator()(ExampleComponent);
+  render(
+    <ExampleNode<string>
+      title='Hello!'
+      disabled={false}
+    />
+  );
+});
+
 test('Should allow passing a "ref" to wrapped component', () => {
   class ExampleComponent extends React.Component {
     render (): ReactNode {


### PR DESCRIPTION
The current [`withAnimator`](https://github.com/arwes/arwes/blob/next/packages/animator/src/withAnimator/withAnimator.ts) higher-order component of the animator package (in the `next` branch), does not support receiving a component with TypeScript generic types and return it with them.

See test case for example.

After component is returned by the HOC, the generic types are lost.

This issue is not new and apparently it does not have a solution as noted in:

- https://github.com/microsoft/TypeScript/issues/30650
- https://github.com/mui-org/material-ui/issues/14544

But I don't know if there are possible workarounds like: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/37087#issuecomment-542793243

This PR contains a unit test which should pass if this feature is supported. If possible, please create a PR to point to this one.

Thank you! :alien: :heart: 