### PR TITLE
fix(Animator): activate late subscribing children and use up to date …

### DIFF
--- a/packages/animator/src/Animator/Animator.component.ts
+++ b/packages/animator/src/Animator/Animator.component.ts
@@ -131,6 +131,8 @@ const Animator: FC<AnimatorProps> = props => {
     const _id = instanceId;
     const _subscribe = (id: number, node: AnimatorChildRef): void => {
       childrenNodesMap.set(id, node);
+      const { flow } = getPersistentAnimatorRef();
+      node.setActivate(flow.value === ENTERING || flow.value === ENTERED);
     };
     const _unsubscribe = (id: number): void => {
       childrenNodesMap.delete(id);
@@ -352,19 +354,19 @@ const Animator: FC<AnimatorProps> = props => {
       animator.onTransition?.(flow);
 
       switch (flow.value) {
-        case ENTERING: animator.onAnimateEntering?.(publicAnimatorRef, ...animateRefs.current); break;
+        case ENTERING: animator.onAnimateEntering?.(animatorRef, ...animateRefs.current); break;
         case ENTERED:
           if (previousFlowValue && previousFlowValue !== ENTERING) {
-            animator.onAnimateEntering?.(publicAnimatorRef, ...animateRefs.current);
+            animator.onAnimateEntering?.(animatorRef, ...animateRefs.current);
           }
-          animator.onAnimateEntered?.(publicAnimatorRef, ...animateRefs.current);
+          animator.onAnimateEntered?.(animatorRef, ...animateRefs.current);
           break;
-        case EXITING: animator.onAnimateExiting?.(publicAnimatorRef, ...animateRefs.current); break;
+        case EXITING: animator.onAnimateExiting?.(animatorRef, ...animateRefs.current); break;
         case EXITED:
           if (previousFlowValue && previousFlowValue !== EXITING) {
-            animator.onAnimateExiting?.(publicAnimatorRef, ...animateRefs.current);
+            animator.onAnimateExiting?.(animatorRef, ...animateRefs.current);
           }
-          animator.onAnimateExited?.(publicAnimatorRef, ...animateRefs.current);
+          animator.onAnimateExited?.(animatorRef, ...animateRefs.current);
           break;
       }
 

--- a/packages/animator/src/withAnimator/withAnimator.delayed-child.sandbox.md
+++ b/packages/animator/src/withAnimator/withAnimator.delayed-child.sandbox.md
@@ -1,0 +1,69 @@
+```jsx
+const COLOR_ON = "#27efb5"; // cyan
+const COLOR_OFF = "#efb527"; // orange
+
+function onAnimateEntering(animator, element) {
+  anime({
+    targets: element.current,
+    easing: "linear",
+    duration: animator.duration.enter,
+    backgroundColor: [COLOR_OFF, COLOR_ON],
+  });
+}
+
+function onAnimateExiting(animator, element) {
+  anime({
+    targets: element.current,
+    easing: "linear",
+    duration: animator.duration.exit,
+    backgroundColor: [COLOR_ON, COLOR_OFF],
+  });
+}
+
+function ItemComponent(props) {
+  const { children } = props;
+  const element = React.useRef();
+  const animator = useAnimator();
+
+  animator.setupAnimateRefs(element);
+
+  return (
+    <div ref={element} style={{ padding: 10, backgroundColor: COLOR_OFF }}>
+      <div>{animator.flow.value}</div>
+      <div style={{ marginLeft: 10 }}>{children}</div>
+    </div>
+  );
+}
+
+const Item = withAnimator({
+  onAnimateEntering,
+  onAnimateExiting,
+})(ItemComponent);
+
+function Sandbox() {
+  const duration = { enter: 1000, exit: 1000 };
+  const [showChild, setShowChild] = React.useState(false);
+  const [activate, setActivate] = React.useState(true);
+
+  React.useEffect(() => {
+    const timeout = setTimeout(() => setShowChild(true), 2000);
+    return () => clearTimeout(timeout);
+  }, []);
+
+  React.useEffect(() => {
+    const timeout = setTimeout(() => setActivate(false), 1950);
+    return () => clearTimeout(timeout);
+  }, []);
+
+  return (
+    <AnimatorGeneralProvider animator={{ duration }}>
+      <Item animator={{ activate: true }}>{showChild && <Item />}</Item>
+      <Item animator={{ activate: activate }}>{showChild && <Item />}</Item>
+      <Item animator={{ activate: false }}>{showChild && <Item />}</Item>
+      <Item animator={{ animate: false }}>{showChild && <Item />}</Item>
+    </AnimatorGeneralProvider>
+  );
+}
+
+render(<Sandbox />);
+```

--- a/packages/core/src/Table/Table.dynamic.sandbox.md
+++ b/packages/core/src/Table/Table.dynamic.sandbox.md
@@ -1,0 +1,65 @@
+```jsx
+const FONT_FAMILY_ROOT = '"Titillium Web", sans-serif';
+const SOUND_READOUT_URL = "/assets/sounds/readout.mp3";
+
+const audioSettings = { common: { volume: 0.25 } };
+const playersSettings = { readout: { src: [SOUND_READOUT_URL], loop: true } };
+const bleepsSettings = { readout: { player: "readout" } };
+const animatorGeneral = {
+  duration: { enter: 200, exit: 200, stagger: 30 },
+};
+const headers = [
+  { id: "a", data: "Header 1" },
+  { id: "b", data: "Header 2" },
+  { id: "c", data: "Header 3" },
+  { id: "d", data: "Header 4" },
+];
+const dataset = Array(10)
+  .fill(0)
+  .map((_, index) => ({
+    id: index,
+    columns: [
+      { id: "p", data: _generateRandomText(2) },
+      { id: "q", data: _generateRandomText(3) },
+      { id: "r", data: _generateRandomText(2) },
+      { id: "s", data: _generateRandomText(8) },
+    ],
+  }));
+const columnWidths = ["20%", "20%", "20%", "40%"];
+
+const Sandbox = () => {
+  const [count, setCount] = React.useState(0);
+
+  React.useEffect(() => {
+    const countIncrease = setTimeout(() => setCount(count + 1), 2000);
+    return () => clearTimeout(countIncrease);
+  }, [count]);
+
+  const reducedDataset = dataset.slice(0, count);
+
+  return (
+    <ArwesThemeProvider>
+      <BleepsProvider
+        audioSettings={audioSettings}
+        playersSettings={playersSettings}
+        bleepsSettings={bleepsSettings}
+      >
+        <StylesBaseline
+          styles={{
+            body: { fontFamily: FONT_FAMILY_ROOT },
+          }}
+        />
+        <AnimatorGeneralProvider animator={animatorGeneral}>
+          <Table
+            headers={headers}
+            dataset={reducedDataset}
+            columnWidths={columnWidths}
+          />
+        </AnimatorGeneralProvider>
+      </BleepsProvider>
+    </ArwesThemeProvider>
+  );
+};
+
+render(<Sandbox />);
+```

--- a/play/playConfigs.js
+++ b/play/playConfigs.js
@@ -23,7 +23,8 @@ const playConfigs = [
           { name: 'nesting', code: require('@repository/packages/animator/src/withAnimator/withAnimator.nesting.sandbox.md').default },
           { name: 'staggering', code: require('@repository/packages/animator/src/withAnimator/withAnimator.staggering.sandbox.md').default },
           { name: 'sequence', code: require('@repository/packages/animator/src/withAnimator/withAnimator.sequence.sandbox.md').default },
-          { name: 'custom-manager', code: require('@repository/packages/animator/src/withAnimator/withAnimator.custom-manager.sandbox.md').default }
+          { name: 'custom-manager', code: require('@repository/packages/animator/src/withAnimator/withAnimator.custom-manager.sandbox.md').default },
+          { name: 'delayed-child', code: require('@repository/packages/animator/src/withAnimator/withAnimator.delayed-child.sandbox.md').default }
         ]
       },
       {
@@ -96,7 +97,8 @@ const playConfigs = [
         name: 'Table',
         sandboxes: [
           { name: 'basic', code: require('@repository/packages/core/src/Table/Table.basic.sandbox.md').default },
-          { name: 'static', code: require('@repository/packages/core/src/Table/Table.static.sandbox.md').default }
+          { name: 'static', code: require('@repository/packages/core/src/Table/Table.static.sandbox.md').default },
+          { name: 'dynamic', code: require('@repository/packages/core/src/Table/Table.dynamic.sandbox.md').default }
         ]
       },
       {


### PR DESCRIPTION
…animatorRef

Please make sure you have reviewed the [contribution guidelines](https://arwes.dev/project/contributing)
for this project.

- [x] Make sure you are making a pull request against the **next** branch
(left side). Also you should start *your branch* off it.
- [x] Check the commit's or even all commits' message styles matches our requested
structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

## Description

Animator children that mount after their parent Animator had already entered weren't being activated, so on subscribe it's now checking if the parent has already entered so it can activate the child at that point.

Also _persistentAnimatorRef and publicAnimatorRef aren't guaranteed to always be the same value, because _setPublicAnimatorRef is asynchronous, so updateAnimatorRef updates _persistentAnimatorRef synchronously and publicAnimatorRef asynchronously. 
The flow value change portion makes decisions based on _persistentAnimatorRef, but passed publicAnimatorRef, resulting in weird behavior when these values were different. Passing _persistentAnimatorRef instead seems fine, the appropriate updates should still happen as long as we're updating publicAnimatorRef, as far as I understand.

Thank you! :alien: :blue_heart:
